### PR TITLE
Promisable methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ Geocoder.prototype = {
    * @api public
    */
 
-  geocode: function ( loc, cbk, opts ) {
+  geocode: function ( loc, opts, cbk ) {
 
     if ( ! loc ) {
         return cbk( new Error( "Geocoder.geocode requires a location.") );
@@ -67,13 +67,12 @@ Geocoder.prototype = {
 
   },
 
-  reverseGeocode: function ( lat, lng, cbk, opts ) {
+  reverseGeocode: function ( lat, lng, opts, cbk ) {
     if ( !lat || !lng ) {
       return cbk( new Error( "Geocoder.reverseGeocode requires a latitude and longitude." ) );
     }
 
-    return this.providerObj.reverseGeocode(this.providerOpts, lat, lng, cbk, opts );
-
+    return this.providerObj.reverseGeocode(this.providerOpts, lat, lng, opts, cbk);
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,20 +1,24 @@
 {
   "name": "geocoder",
-  "description": "Geocoding through Google's Developer API",
+  "description": "node wrapper around google's geocoder api",
   "version": "0.2.2",
   "main": "./index.js",
-  "description": "node wrapper around google's geocoder api",
   "author": "Stephen Wyatt Bush <stephen.wyatt@gmail.com>",
-  "repository" : "git://github.com/wyattdanger/geocoder",
-  "homepage" : "https://github.com/wyattdanger/geocoder",
-  "keywords" : [ "google", "geocode", "geonames", "reverse geocode" ],
+  "repository": "git://github.com/wyattdanger/geocoder",
+  "homepage": "https://github.com/wyattdanger/geocoder",
+  "keywords": [
+    "google",
+    "geocode",
+    "geonames",
+    "reverse geocode"
+  ],
   "license": {
     "type": "Apachev2",
     "url": "http://www.apache.org/licenses/LICENSE-2.0"
   },
-  "dependencies" : {
-    "underscore" : "1.3.3",
-    "request":"2.11.1"
+  "dependencies": {
+    "extend": "^3.0.0",
+    "request": "2.11.1"
   },
   "optionalDependencies": {
     "xml2js": "0.2.0"

--- a/providers/geonames.js
+++ b/providers/geonames.js
@@ -2,11 +2,11 @@
 // xml2js is optional because only needed for geonames support
 var xml2js = require("xml2js");
 var request = require("request");
-var _ = require('underscore');
+var extend = require('extend');
 
 exports.geocode = function ( providerOpts, loc, cbk, opts ) {
 
-  var options = _.extend({q: loc, maxRows: 10, username:providerOpts.username||"demo" }, opts || {});
+  var options = extend({q: loc, maxRows: 10, username:providerOpts.username||"demo" }, opts || {});
 
   request({
     uri:"http://api.geonames.org/searchJSON",
@@ -26,7 +26,7 @@ exports.geocode = function ( providerOpts, loc, cbk, opts ) {
 
 exports.reverseGeocode = function ( providerOpts, lat, lng, cbk, opts ) {
 
-  var options = _.extend({lat:lat, lng:lng, username:providerOpts.username||"demo" }, opts || {});
+  var options = extend({lat:lat, lng:lng, username:providerOpts.username||"demo" }, opts || {});
 
   request({
     uri:"http://api.geonames.org/extendedFindNearby",

--- a/providers/geonames.js
+++ b/providers/geonames.js
@@ -4,7 +4,7 @@ var xml2js = require("xml2js");
 var request = require("request");
 var extend = require('extend');
 
-exports.geocode = function ( providerOpts, loc, cbk, opts ) {
+exports.geocode = function ( providerOpts, loc, opts, cbk ) {
 
   var options = extend({q: loc, maxRows: 10, username:providerOpts.username||"demo" }, opts || {});
 
@@ -24,7 +24,7 @@ exports.geocode = function ( providerOpts, loc, cbk, opts ) {
   });
 };
 
-exports.reverseGeocode = function ( providerOpts, lat, lng, cbk, opts ) {
+exports.reverseGeocode = function ( providerOpts, lat, lng, opts, cbk ) {
 
   var options = extend({lat:lat, lng:lng, username:providerOpts.username||"demo" }, opts || {});
 

--- a/providers/google.js
+++ b/providers/google.js
@@ -1,7 +1,7 @@
 var request = require("request");
 var extend = require('extend');
 
-exports.geocode = function ( providerOpts, loc, cbk, opts ) {
+exports.geocode = function ( providerOpts, loc, opts, cbk ) {
 
   var options = extend({address: loc}, opts || {});
   var uri = "http" + ( options.key ? "s" : "" ) + "://maps.googleapis.com/maps/api/geocode/json"
@@ -21,10 +21,10 @@ exports.geocode = function ( providerOpts, loc, cbk, opts ) {
   });
 };
 
-exports.reverseGeocode = function ( providerOpts, lat, lng, cbk, opts ) {
+exports.reverseGeocode = function ( providerOpts, lat, lng, opts, cbk ) {
 
   var options = extend({latlng: lat + ',' + lng}, opts || {});
-  var uri = "http" + ( options.key ? "s" : "" ) + "://maps.googleapis.com/maps/api/geocode/json"
+  var uri = "http" + ( options.key ? "s" : "" ) + "://maps.googleapis.com/maps/api/geocode/json";
 
   request({
     uri:uri,

--- a/providers/google.js
+++ b/providers/google.js
@@ -3,7 +3,7 @@ var _ = require('underscore');
 
 exports.geocode = function ( providerOpts, loc, cbk, opts ) {
 
-  var options = _.extend({sensor: false, address: loc}, opts || {});
+  var options = _.extend({address: loc}, opts || {});
   var uri = "http" + ( options.key ? "s" : "" ) + "://maps.googleapis.com/maps/api/geocode/json"
   request({
     uri: uri,
@@ -23,7 +23,7 @@ exports.geocode = function ( providerOpts, loc, cbk, opts ) {
 
 exports.reverseGeocode = function ( providerOpts, lat, lng, cbk, opts ) {
 
-  var options = _.extend({sensor: false, latlng: lat + ',' + lng}, opts || {});
+  var options = _.extend({latlng: lat + ',' + lng}, opts || {});
   var uri = "http" + ( options.key ? "s" : "" ) + "://maps.googleapis.com/maps/api/geocode/json"
 
   request({

--- a/providers/google.js
+++ b/providers/google.js
@@ -1,9 +1,9 @@
 var request = require("request");
-var _ = require('underscore');
+var extend = require('extend');
 
 exports.geocode = function ( providerOpts, loc, cbk, opts ) {
 
-  var options = _.extend({address: loc}, opts || {});
+  var options = extend({address: loc}, opts || {});
   var uri = "http" + ( options.key ? "s" : "" ) + "://maps.googleapis.com/maps/api/geocode/json"
   request({
     uri: uri,
@@ -23,7 +23,7 @@ exports.geocode = function ( providerOpts, loc, cbk, opts ) {
 
 exports.reverseGeocode = function ( providerOpts, lat, lng, cbk, opts ) {
 
-  var options = _.extend({latlng: lat + ',' + lng}, opts || {});
+  var options = extend({latlng: lat + ',' + lng}, opts || {});
   var uri = "http" + ( options.key ? "s" : "" ) + "://maps.googleapis.com/maps/api/geocode/json"
 
   request({

--- a/providers/yahoo.js
+++ b/providers/yahoo.js
@@ -3,7 +3,7 @@ var xml2js = require("xml2js");
 var request = require("request");
 var extend = require('extend');
 
-exports.geocode = function ( providerOpts, loc, cbk, opts ) {
+exports.geocode = function ( providerOpts, loc, opts, cbk ) {
 
   var options = extend({q: loc, flags: "J", appid:providerOpts.appid||"[yourappidhere]" }, opts || {});
 
@@ -24,7 +24,7 @@ exports.geocode = function ( providerOpts, loc, cbk, opts ) {
 };
 
 // yahoo placefinder api http://developer.yahoo.com/geo/placefinder/guide/
-exports.reverseGeocode = function ( providerOpts, lat, lng, cbk, opts ) {
+exports.reverseGeocode = function ( providerOpts, lat, lng, opts, cbk ) {
 
   var options = extend({q: lat+", "+lng, gflags:"R", flags: "J", appid:providerOpts.appid||"[yourappidhere]" }, opts || {});
 

--- a/providers/yahoo.js
+++ b/providers/yahoo.js
@@ -1,11 +1,11 @@
 // xml2js is optional because only needed for geonames support
 var xml2js = require("xml2js");
 var request = require("request");
-var _ = require('underscore');
+var extend = require('extend');
 
 exports.geocode = function ( providerOpts, loc, cbk, opts ) {
 
-  var options = _.extend({q: loc, flags: "J", appid:providerOpts.appid||"[yourappidhere]" }, opts || {});
+  var options = extend({q: loc, flags: "J", appid:providerOpts.appid||"[yourappidhere]" }, opts || {});
 
   request({
     uri:"http://where.yahooapis.com/geocode",
@@ -26,7 +26,7 @@ exports.geocode = function ( providerOpts, loc, cbk, opts ) {
 // yahoo placefinder api http://developer.yahoo.com/geo/placefinder/guide/
 exports.reverseGeocode = function ( providerOpts, lat, lng, cbk, opts ) {
 
-  var options = _.extend({q: lat+", "+lng, gflags:"R", flags: "J", appid:providerOpts.appid||"[yourappidhere]" }, opts || {});
+  var options = extend({q: lat+", "+lng, gflags:"R", flags: "J", appid:providerOpts.appid||"[yourappidhere]" }, opts || {});
 
   request({
     uri:"http://where.yahooapis.com/geocode",


### PR DESCRIPTION
I've refactored the methods to use callback as last parameter, which is the node.js style. This will allow libraries like Bluebird to allow [promisify all](https://github.com/petkaantonov/bluebird/blob/master/API.md#promisepromisifyallobject-target--object-options---object) methods.

Also removed underscore dependency and used `extend` instead, which is much more lightweight and more suited for the specific purpose.