### PR TITLE
Update depencency version number for request

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,11 +10,11 @@
  * Version
  */
 
-var version = '0.2.1';
+var version = '0.2.3';
 
 
 /**
- * Geocoder 
+ * Geocoder
  */
 
 function Geocoder () {
@@ -30,7 +30,7 @@ Geocoder.prototype = {
 
   /**
    * Selects a webservice provider
-   * 
+   *
    * @param {String} name, required
    * @param {Object} opts, optional
    * @api public
@@ -50,7 +50,7 @@ Geocoder.prototype = {
 
   /**
    * Request geocoordinates of given `loc` from Google
-   * 
+   *
    * @param {String} loc, required
    * @param {Function} cbk, required
    * @param {Object} opts, optional
@@ -62,7 +62,7 @@ Geocoder.prototype = {
     if ( ! loc ) {
         return cbk( new Error( "Geocoder.geocode requires a location.") );
     }
-    
+
     return this.providerObj.geocode(this.providerOpts, loc, cbk, opts);
 
   },
@@ -78,7 +78,7 @@ Geocoder.prototype = {
 
   /**
    * Return Geocoder version
-   * 
+   *
    * @api public
    */
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geocoder",
   "description": "Geocoding through Google's Developer API",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "main": "./index.js",
   "description": "node wrapper around google's geocoder api",
   "author": "Stephen Wyatt Bush <stephen.wyatt@gmail.com>",
@@ -14,7 +14,7 @@
   },
   "dependencies" : {
     "underscore" : "1.3.3",
-    "request":"2.11.1"
+    "request":"^2.75.0"
   },
   "optionalDependencies": {
     "xml2js": "0.2.0"


### PR DESCRIPTION
Updating the version of the request package used to the latest. For me at least this is to enable request's in-built support of proxies through `process.env.HTTPS_PROXY`.
